### PR TITLE
Travis for multiple versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
+sudo: false
 language: python
 os: linux
-env:
- - DIST=trusty
 
 python:
-   - "2.7_with_system_site_packages"
+  - "2.7"
+  - "3.5"
+  - "3.6"
+
+# Python 3.7 needs a special treatment until it is supported by default
+# https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+matrix:
+  include:
+    - python: "3.7"
+      sudo: required
+      dist: xenial
 
 addons:
    apt:
@@ -13,20 +22,8 @@ addons:
          - netcdf-bin
          - libnetcdf-dev
 
-before_install:
-   - "export DISPLAY=:99.0"
-   - "sh -e /etc/init.d/xvfb start"
-   - sudo apt-get update -qq
-   - sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-mpltoolkits.basemap
-   - sudo pip install matplotlib==1.1.1
-
 install:
-   - sudo pip install .
+  - pip install tox-travis==0.11
 
 script:
-   - pip install coveralls pep8
-   - nosetests -v --with-coverage --cover-erase --cover-package=verif
-   - verif examples/raw.txt examples/kf.txt -m mae -f test.png
-
-after_success:
-   - coveralls
+  - tox

--- a/run_coveralls.py
+++ b/run_coveralls.py
@@ -1,0 +1,14 @@
+#!/bin/env/python
+
+# From: https://stackoverflow.com/a/33012308
+# Runs coveralls if Travis CI is detected
+
+import os
+from subprocess import call
+
+if __name__ == '__main__':
+    if 'TRAVIS' in os.environ:
+        rc = call('coveralls')
+        raise SystemExit(rc)
+    else:
+        print("Travis was not detected -> Skipping coveralls")

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
-# tox (https://tox.readthedocs.io/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py27, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
+# set the matplitlib backend to one that does not require the xserver
 setenv = MPLBACKEND = Agg
+passenv =
+  TRAVIS
+  TRAVIS_*
+
 deps =
     nose
     pep8
+    coveralls
 commands =
-    nosetests
+    nosetests -v --with-coverage --cover-erase --cover-package=verif
+    verif examples/raw.txt examples/kf.txt -m mae -f test.png
+    python {toxinidir}/run_coveralls.py


### PR DESCRIPTION
Hi,

so I added the changes to run CI on multiple Python versions. I have noticed that you also made a few commits into this issue but I took a bit different direction. I do not run `notests` directly but leave the execution to `tox`. This is because you can then use tox on your local machine as well to test the same environments as Travis would be running.

What is working:
- separate jobs for each Python version (2.7, 3.5, 3.6, 3.7)
  - Python 3.7 needed a workaround because it is not available in the default Linux distribution that Travis CI uses
- `coveralls` works as well
   - there is a condition that `coveralls` is run only in Travis. The local tests on the developer's machine ignore the `coveralls` call

You can see it here:
- https://travis-ci.org/tommz9/verif
- https://coveralls.io/github/tommz9/verif